### PR TITLE
Fix emoji error

### DIFF
--- a/py_heideltime/py_heideltime.py
+++ b/py_heideltime/py_heideltime.py
@@ -3,6 +3,7 @@ import codecs
 import imp
 import platform
 import subprocess
+import emoji
 import re
 from py_heideltime.validate_input import verify_temporal_tagger
 import time
@@ -183,9 +184,13 @@ def get_Path():
         full_path = str(pp) + '''\\\Heideltime\\\TreeTaggerWindows'''
     return path, full_path
 
-import emoji
+def get_emoji_regexp():
+    emojis = sorted(emoji.EMOJI_DATA, key=len, reverse=True)
+    pattern = u'(' + u'|'.join(re.escape(u) for u in emojis) + u')'
+    return re.compile(pattern)
+
 def remove_emoji(text):
-    return emoji.get_emoji_regexp().sub(u'', text)
+    return get_emoji_regexp().sub(u'', text)
 
 def text_has_emoji(text):
     if  emoji.distinct_emoji_list(text):

--- a/tests/test_py_heideltime.py
+++ b/tests/test_py_heideltime.py
@@ -1,0 +1,11 @@
+from py_heideltime.py_heideltime import remove_emoji
+
+
+def test_remove_emoji():
+    """Assert that the emojis are being removed."""
+    text = "text with emoji 😀"
+    expected_result = "text with emoji "
+
+    result = remove_emoji(text)
+
+    assert result == expected_result


### PR DESCRIPTION
Fixed emoji error by adding a `get_emoji_regexp()` function as proposed in this [comment](https://github.com/carpedm20/emoji/issues/222#issuecomment-1200303280). 

Another solution would be force the `emoji` package version to  be lower than 1.7.0, however the committed solution should be better in long term.